### PR TITLE
Fixing the egress security group creation.

### DIFF
--- a/cloudformation/aws_nw_fw.yml
+++ b/cloudformation/aws_nw_fw.yml
@@ -336,10 +336,6 @@ Resources:
           ToPort: 22
           CidrIp: !Ref SshAccessCidr
           Description: 'Allow SSH'
-      SecurityGroupEgress:
-        - Description: Allow all outbound traffic
-          IpProtocol: tcp
-          CidrIp: 0.0.0.0/0
       Tags:
         - Key: Application
           Value: !Ref 'AWS::StackId'
@@ -361,10 +357,6 @@ Resources:
           ToPort: 22
           CidrIp: !Ref SshAccessCidr
           Description: 'Allow SSH' 
-      SecurityGroupEgress:
-        - Description: Allow all outbound traffic
-          IpProtocol: tcp
-          CidrIp: 0.0.0.0/0
       Tags:
         - Key: Application
           Value: !Ref 'AWS::StackId'


### PR DESCRIPTION
The stack fails because it is expected that range of ports will be provided. Considering stateful nature of the security groups it has no value to specify tcp traffic only. Removing egress rule part will make it permissive and will allow stack to progress and not to fail. This will also insure that all egress traffic will be allowed. 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
