### PR TITLE
Update aws_nw_fw.yml Fixing missing route

### DIFF
--- a/cloudformation/aws_nw_fw.yml
+++ b/cloudformation/aws_nw_fw.yml
@@ -520,6 +520,13 @@ Resources:
       RouteTableId: !Ref InspectionANFRT
       DestinationCidrBlock: 0.0.0.0/0
       TransitGatewayId: !Ref TransitGateway
+  InspectionVPCRoute2:
+    Type: 'AWS::EC2::Route'
+    DependsOn: Firewall
+    Properties:
+      RouteTableId: !Ref InspectionTGWRT
+      DestinationCidrBlock: 0.0.0.0/0
+      VpcEndpointId: !Select [1, !Split [":", !Select [0, !GetAtt Firewall.EndpointIds]]]
   EgressVPCRoute1:
     Type: 'AWS::EC2::Route'
     DependsOn: EgressVpcAttachment


### PR DESCRIPTION
Fixing the lack of route towards VPC endpoint.
This fix will deliver a fully working solution without any manual work required. The resource will create a static route in the RT and will point 0.0.0.0/0 to the vpc-endpoint target (gateway load balance) used by AWS network firewall.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
